### PR TITLE
Update __kube_prompt.fish added absolute pat for `test` and `stat` commands

### DIFF
--- a/__kube_prompt.fish
+++ b/__kube_prompt.fish
@@ -5,7 +5,7 @@
 function __kube_ps_update_cache
   function __kube_ps_cache_context
     set -l ctx (kubectl config current-context 2>/dev/null)
-    if test $status -eq 0
+    if /bin/test $status -eq 0
       set -g __kube_ps_context "$ctx"
     else
       set -g __kube_ps_context "n/a"
@@ -14,7 +14,7 @@ function __kube_ps_update_cache
 
   function __kube_ps_cache_namespace
     set -l ns (kubectl config view --minify -o 'jsonpath={..namespace}' 2>/dev/null)
-    if test -n "$ns"
+    if /bin/test -n "$ns"
       set -g __kube_ps_namespace "$ns"
     else
       set -g __kube_ps_namespace "default"
@@ -22,11 +22,11 @@ function __kube_ps_update_cache
   end
 
   set -l kubeconfig "$KUBECONFIG"
-  if test -z "$kubeconfig"
+  if /bin/test -z "$kubeconfig"
     set kubeconfig "$HOME/.kube/config"
   end
 
-  if test "$kubeconfig" != "$__kube_ps_kubeconfig"
+  if /bin/test "$kubeconfig" != "$__kube_ps_kubeconfig"
     __kube_ps_cache_context
     __kube_ps_cache_namespace
     set -g __kube_ps_kubeconfig "$kubeconfig"
@@ -35,8 +35,8 @@ function __kube_ps_update_cache
   end
 
   for conf in (string split ':' "$kubeconfig")
-    if test -r "$conf"
-      if test -z "$__kube_ps_timestamp"; or test (stat -f '%m' "$conf") -gt "$__kube_ps_timestamp"
+    if /bin/test -r "$conf"
+      if /bin/test -z "$__kube_ps_timestamp"; or /bin/test (/usr/bin/stat -f '%m' "$conf") -gt "$__kube_ps_timestamp"
         __kube_ps_cache_context
         __kube_ps_cache_namespace
         set -g __kube_ps_kubeconfig "$kubeconfig"
@@ -48,7 +48,7 @@ function __kube_ps_update_cache
 end
 
 function __kube_prompt
-  if test -z "$__kube_ps_enabled"; or test $__kube_ps_enabled -ne 1
+  if /bin/test -z "$__kube_ps_enabled"; or /bin/test $__kube_ps_enabled -ne 1
     return
   end
 


### PR DESCRIPTION
must be tested with linux, but I think it's ok. https://github.com/aluxian/fish-kube-prompt/issues/1