### PR TITLE
fix some errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 mkdir -p ~/.config/fish/functions/
 cd ~/.config/fish/
 git clone https://github.com/aluxian/fish-kube-prompt
-ln -s ../fish-kube-prompt/__kube_prompt.fish functions/
-ln -s ../fish-kube-prompt/kube_ps.fish functions/
+ln -s ../fish-kube-prompt/functions/__kube_prompt.fish functions/
+ln -s ../fish-kube-prompt/functions/kube_ps.fish functions/
 ```
 
 Then create or edit `~/.config/fish/functions/fish_prompt.fish` to include

--- a/functions/__kube_prompt.fish
+++ b/functions/__kube_prompt.fish
@@ -5,7 +5,7 @@
 function __kube_ps_update_cache
   function __kube_ps_cache_context
     set -l ctx (kubectl config current-context 2>/dev/null)
-    if /bin/test $status -eq 0
+    if test $status -eq 0
       set -g __kube_ps_context "$ctx"
     else
       set -g __kube_ps_context "n/a"
@@ -14,7 +14,7 @@ function __kube_ps_update_cache
 
   function __kube_ps_cache_namespace
     set -l ns (kubectl config view --minify -o 'jsonpath={..namespace}' 2>/dev/null)
-    if /bin/test -n "$ns"
+    if test -n "$ns"
       set -g __kube_ps_namespace "$ns"
     else
       set -g __kube_ps_namespace "default"
@@ -22,11 +22,11 @@ function __kube_ps_update_cache
   end
 
   set -l kubeconfig "$KUBECONFIG"
-  if /bin/test -z "$kubeconfig"
+  if test -z "$kubeconfig"
     set kubeconfig "$HOME/.kube/config"
   end
 
-  if /bin/test "$kubeconfig" != "$__kube_ps_kubeconfig"
+  if test "$kubeconfig" != "$__kube_ps_kubeconfig"
     __kube_ps_cache_context
     __kube_ps_cache_namespace
     set -g __kube_ps_kubeconfig "$kubeconfig"
@@ -35,8 +35,8 @@ function __kube_ps_update_cache
   end
 
   for conf in (string split ':' "$kubeconfig")
-    if /bin/test -r "$conf"
-      if /bin/test -z "$__kube_ps_timestamp"; or /bin/test (/usr/bin/stat -f '%m' "$conf") -gt "$__kube_ps_timestamp"
+    if test -r "$conf"
+      if test -z "$__kube_ps_timestamp"; or test (/usr/bin/stat -f '%m' "$conf") -gt "$__kube_ps_timestamp"
         __kube_ps_cache_context
         __kube_ps_cache_namespace
         set -g __kube_ps_kubeconfig "$kubeconfig"
@@ -48,7 +48,7 @@ function __kube_ps_update_cache
 end
 
 function __kube_prompt
-  if /bin/test -z "$__kube_ps_enabled"; or /bin/test $__kube_ps_enabled -ne 1
+  if test -z "$__kube_ps_enabled"; or test $__kube_ps_enabled -ne 1
     return
   end
 

--- a/functions/__kube_prompt.fish
+++ b/functions/__kube_prompt.fish
@@ -36,7 +36,7 @@ function __kube_ps_update_cache
 
   for conf in (string split ':' "$kubeconfig")
     if test -r "$conf"
-      if test -z "$__kube_ps_timestamp"; or test (/usr/bin/stat -f '%m' "$conf") -gt "$__kube_ps_timestamp"
+      if test -z "$__kube_ps_timestamp"; or test (/usr/bin/stat -f '%Y' "$conf") -gt "$__kube_ps_timestamp"
         __kube_ps_cache_context
         __kube_ps_cache_namespace
         set -g __kube_ps_kubeconfig "$kubeconfig"


### PR DESCRIPTION
I fixed some errors.
- fixed installing guide in README
  - maybe this is caused by  https://github.com/aluxian/fish-kube-prompt/pull/6
- fixed test commend in order to run in all environments.
  - e.g.) in Ubuntu, test command is installed at `/usr/bin/test` , so I just rewrited it as `test` ( this is already done in  `kube_ps.fish` )
- fixed #5 