### PR TITLE
Detect what version of python is installed

### DIFF
--- a/functions/__kube_prompt.fish
+++ b/functions/__kube_prompt.fish
@@ -22,10 +22,13 @@ function __kube_ps_update_cache
   end
 
   function __stat_mtime
+    # Get installed python executable
+    set python (which -a python python2 python2.7 python3 python3.6 | head -n 1)
+
     #-- cross-platform workaround; POSIX didn't specify stat(1) and so
     #-- its interface is incompatibly different on Mac OS and Linux.
     #-- see https://unix.stackexchange.com/q/561927/3097
-    python -c "print(__import__('os').stat(__import__('sys').argv[1]).st_mtime)" $argv
+    $python -c "print(__import__('os').stat(__import__('sys').argv[1]).st_mtime)" $argv
   end
 
   set -l kubeconfig "$KUBECONFIG"


### PR DESCRIPTION
On recent version of macos python 2 is no longer installed by default. This pull requests attempts to detect what versions of Python is installed on the users mache and use on of them for running Python commands.
